### PR TITLE
Detect for a composer.json file aswell as index.php

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -f "$1/index.php" ]; then
+if [ -f "$1/index.php" ] || [ -f "$1/composer.json" ]; then
   echo "PHP (HHVM)" && exit 0
 else
   exit 1


### PR DESCRIPTION
Detect for a composer.json file aswell as index.php allows to not create... empty index.php file for projects that are using Symfony, Silex and so on

Tested as `./bin/detect /path/to/symfony-app` and it returns `PHP (HHVM)` as expected.

This fixes GH #1
