### PR TITLE
Add LD_LIBRARY_PATH as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ If your app needs a custom [`config.hdf`](https://github.com/facebook/hiphop-php
       DefaultDocument = index.php
     }
 
+## CLI
+The buildpack can't set environment variables (slug compilation takes place on different dynos). If you plan to run HHVM from CLI, you can define `LD_LIBRARY_PATH` by running:
+    
+    heroku config:add LD_LIBRARY_PATH=vendor/hhvm/
+
 ## Performance
 
 You should see anywhere between 2x and 10x performance gains on your app. 


### PR DESCRIPTION
Apparently, there's no way to set environment variables from the buildpack (at least not after some 30 min of looking around for a solution). This makes sense IMO since slug compilation takes part on different dynos. There seems to be a labs feature allowing this, but it's not encouraged and it doesn't seem to be any better than running an extra heroku command, so I just added this in the docs.
