### PR TITLE
Update compile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -58,7 +58,7 @@ if [ -f "composer.json" ]; then
 
   GIT_DIR_ORIG=$GIT_DIR
   unset GIT_DIR
-  LD_LIBRARY_PATH=vendor/hhvm/ vendor/hhvm/hhvm -c vendor/hhvm/config.hdf composer.phar install -n | indent
+  LD_LIBRARY_PATH=vendor/hhvm/ vendor/hhvm/hhvm -c vendor/hhvm/config.hdf composer.phar install -n --no-dev -o | indent
   rm -rf vendor/**/.git
   export GIT_DIR=$GIT_DIR_ORIG
 else


### PR DESCRIPTION
Dump optimized autoload and do not install development files. Does not make sense to install stuff like PHPUnit or other development tools.
